### PR TITLE
Fix Booster import, remove try/exception

### DIFF
--- a/dtreeviz/models/shadow_decision_tree.py
+++ b/dtreeviz/models/shadow_decision_tree.py
@@ -9,10 +9,11 @@ import sklearn
 
 try:
     import xgboost as xgb
-    import xgboost.core.Booster as Booster
+    from xgboost.core import Booster
 except:
     xgb = None
     Booster = None
+
 
 class ShadowDecTree(ABC):
     """
@@ -453,7 +454,9 @@ class ShadowDecTree(ABC):
             from dtreeviz.models import xgb_decision_tree
             return xgb_decision_tree.ShadowXGBDTree(tree_model, tree_index, x_data, y_data,
                                                     feature_names, target_name, class_names)
-        else: raise ValueError(f"Tree model must be in (DecisionTreeRegressor, DecisionTreeClassifier, xgboost.core.Booster, but was {tree_model.__class__.__name__}")
+        else:
+            raise ValueError(
+                f"Tree model must be in (DecisionTreeRegressor, DecisionTreeClassifier, xgboost.core.Booster, but was {tree_model.__class__.__name__}")
 
 
 class ShadowDecTreeNode():

--- a/dtreeviz/models/xgb_decision_tree.py
+++ b/dtreeviz/models/xgb_decision_tree.py
@@ -10,10 +10,12 @@ from dtreeviz.models.shadow_decision_tree import ShadowDecTree
 
 try:
     import xgboost as xgb
-    import xgboost.core.Booster as Booster
-except:
-    xgb = None
-    Booster = None
+    from xgboost.core import Booster
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(
+        f"Failed to import xgboost. Make sure it is installed properly. You can install it as an optional "
+        f"dependency with pip install dtreeviz[xgboost]")
+
 
 class ShadowXGBDTree(ShadowDecTree):
     LEFT_CHILDREN_COLUMN = "Yes"
@@ -43,12 +45,6 @@ class ShadowXGBDTree(ShadowDecTree):
         super().__init__(booster, x_data, y_data, feature_names, target_name, class_names)
 
     def is_fit(self):
-        try:
-            from xgboost.core import Booster
-        except Exception as e:
-            raise ImportError("Failed to import xgboost. Make sure it is"
-                    "installed properly. You can install it as an optional"
-                    "dependency with pip install dtreeviz[xgboost]")
         return isinstance(self.booster, Booster)
 
     # TODO - add implementation
@@ -96,14 +92,7 @@ class ShadowXGBDTree(ShadowDecTree):
         Return dictionary mapping node id to list of sample indexes considered by
         the feature/split decision.
         """
-        # Doc say: "Return a node indicator matrix where non zero elements
-        #           indicates that the samples goes through the nodes."
-        try:
-            import xgboost as xgb
-        except Exception as e:
-            raise ImportError("Failed to import xgboost. Make sure it is"
-                    "installed properly. You can install it as an optional"
-                    "dependency with pip install dtreeviz[xgboost]")
+
         if self.node_to_samples is not None:
             return self.node_to_samples
 


### PR DESCRIPTION
thanks @oegedijk for your PR.

I've checkout and tried it... and I have some suggestions.

1. "import xgboost.core.Booster as Booster" generate error " No module named 'xgboost.core.Booster'; 'xgboost.core' is not a package" .

2. raised an ModuleNotFoundError at the import section. In this way the user will receive the error when importing the xgb_decision_tree.py module. We will not need the try/exception through the code...which doesn't make the code to look nice :)

3.  about the xgboost size... it is 13MB. pyspark is 218MB, so I think it's worthwhile to make pyspark optional.

Waiting for your feedback :)

 